### PR TITLE
Steam dialog with focus

### DIFF
--- a/manifests/UplayLibrary_Builtin.yaml
+++ b/manifests/UplayLibrary_Builtin.yaml
@@ -24,3 +24,9 @@ Packages:
     PackageUrl: https://github.com/JosefNemec/PlayniteExtensions/releases/download/2.2/UplayLibrary_Builtin_2_3.pext
     Changelog:
       - Play time tracking could start sooner than it should (by darklinkpower)
+  - Version: 2.4
+    RequiredApiVersion: 6.0.0
+    ReleaseDate: 2022-12-01
+    PackageUrl: https://github.com/JosefNemec/PlayniteExtensions/releases/download/2.2/UplayLibrary_Builtin_2_4.pext
+    Changelog:
+      - Removed string references to Uplay client (by Xenor)

--- a/source/Libraries/UplayLibrary/Properties/AssemblyInfo.cs
+++ b/source/Libraries/UplayLibrary/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.3.0.*")]
+[assembly: AssemblyVersion("2.4.0.*")]
 [assembly: InternalsVisibleTo("UplayLibrary.Tests")]

--- a/source/Libraries/UplayLibrary/Properties/AssemblyInfo.cs
+++ b/source/Libraries/UplayLibrary/Properties/AssemblyInfo.cs
@@ -6,7 +6,7 @@ using System.Runtime.InteropServices;
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
 [assembly: AssemblyTitle("UplayLibrary")]
-[assembly: AssemblyDescription("Uplay library support plugin for Playnite")]
+[assembly: AssemblyDescription("Ubisoft Connect library support plugin for Playnite")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCompany("")]
 [assembly: AssemblyProduct("UplayLibrary")]

--- a/source/Libraries/UplayLibrary/UplayClient.cs
+++ b/source/Libraries/UplayLibrary/UplayClient.cs
@@ -28,7 +28,7 @@ namespace UplayLibrary
             var mainProc = Process.GetProcessesByName("upc").FirstOrDefault();
             if (mainProc == null)
             {
-                logger.Info("Uplay client is no longer running, no need to shut it down.");
+                logger.Info("Ubisoft Connect client is no longer running, no need to shut it down.");
                 return;
             }
 
@@ -40,7 +40,7 @@ namespace UplayLibrary
                 var coreRes = ProcessStarter.StartProcessWait(CmdLineTools.TaskKill, $"/pid {mainProc.Id}", null, out var stdOut1, out var stdErr1);
                 if (coreRes != 0)
                 {
-                    logger.Error($"Failed to close uplay UI processes: {coreRes}, {stdErr1}");
+                    logger.Error($"Failed to close Ubisoft Connect UI processes: {coreRes}, {stdErr1}");
                 }
 
                 // TODO change this to proper wait for all processes to close
@@ -50,7 +50,7 @@ namespace UplayLibrary
             var mainRes = ProcessStarter.StartProcessWait(CmdLineTools.TaskKill, $"/f /pid {mainProc.Id}", null, out var stdOut, out var stdErr);
             if (mainRes != 0)
             {
-                logger.Error($"Failed to close uplay client: {mainRes}, {stdErr}");
+                logger.Error($"Failed to close Ubisoft Connect client: {mainRes}, {stdErr}");
             }
         }
     }

--- a/source/Libraries/UplayLibrary/UplayLibrary.cs
+++ b/source/Libraries/UplayLibrary/UplayLibrary.cs
@@ -129,12 +129,12 @@ namespace UplayLibrary
                 try
                 {
                     installedGames = GetInstalledGames();
-                    Logger.Debug($"Found {installedGames.Count} installed Uplay games.");
+                    Logger.Debug($"Found {installedGames.Count} installed Ubisoft Connect games.");
                     allGames.AddRange(installedGames);
                 }
                 catch (Exception e)
                 {
-                    Logger.Error(e, "Failed to import installed Uplay games.");
+                    Logger.Error(e, "Failed to import installed Ubisoft Connect games.");
                     importError = e;
                 }
             }
@@ -144,7 +144,7 @@ namespace UplayLibrary
                 try
                 {
                     var libraryGames = GetLibraryGames();
-                    Logger.Debug($"Found {libraryGames.Count} library Uplay games.");
+                    Logger.Debug($"Found {libraryGames.Count} library Ubisoft Connect games.");
                     foreach (var libGame in libraryGames)
                     {
                         var installed = installedGames.FirstOrDefault(a => a.GameId == libGame.GameId);
@@ -162,7 +162,7 @@ namespace UplayLibrary
                 }
                 catch (Exception e)
                 {
-                    Logger.Error(e, "Failed to import uninstalled Uplay games.");
+                    Logger.Error(e, "Failed to import uninstalled Ubisoft Connect games.");
                     importError = e;
                 }
             }

--- a/source/Libraries/UplayLibrary/UplayMetadataProvider.cs
+++ b/source/Libraries/UplayLibrary/UplayMetadataProvider.cs
@@ -23,7 +23,7 @@ namespace UplayLibrary
             }
             catch (Exception e)
             {
-                logger.Error(e, "Failed to get Uplay product info from cache.");
+                logger.Error(e, "Failed to get Ubisoft Connect product info from cache.");
             }
         }
 

--- a/source/Libraries/UplayLibrary/extension.yaml
+++ b/source/Libraries/UplayLibrary/extension.yaml
@@ -1,7 +1,7 @@
 ﻿Id: UplayLibrary_Builtin
 Name: Ubisoft Connect library integration
 Author: Playnite
-Version: 2.3
+Version: 2.4
 Module: UplayLibrary.dll
 Type: GameLibrary
 Icon: Resources\uplayicon.png

--- a/source/Libraries/UplayLibrary/extension.yaml
+++ b/source/Libraries/UplayLibrary/extension.yaml
@@ -1,5 +1,5 @@
 ﻿Id: UplayLibrary_Builtin
-Name: Uplay library integration
+Name: Ubisoft Connect library integration
 Author: Playnite
 Version: 2.3
 Module: UplayLibrary.dll


### PR DESCRIPTION
This approach to focus the Steam launch dialog will work even if a different window (like incoming chat messages) own the MainWindowHandle.

If only one launch dialog is open it will be focused.
If more than one launch dialog is open the launch dialogs will be focused after each other with order being old to new. Resulting in the launch dialog of the most recent game launch being the top.